### PR TITLE
Mark message as read enpoint added and auto start from persistent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,29 @@ npm run dev or pnpm dev
 
 <br/>
 
+- `POST` /messages/read
+
+    **Mark one or more messages as read**
+  - **keys**: Array of message keys to mark as read (`remoteJid`, `id`, optional `fromMe`, `participant`)
+  - **presence** *(optional)*: unavailable | available | composing | recording | paused
+  - **jid** *(optional)*: JID used for presence update (if omitted, uses the first key `remoteJid`)
+
+    ```json
+    {
+      "keys": [
+        {
+          "remoteJid": "5215512345678@s.whatsapp.net",
+          "id": "ABGGFlA5FpafAgo6EhQNmjM2",
+          "fromMe": false
+        }
+      ],
+      "presence": "available"
+    }
+    ```
+    `curl -X POST http://localhost:8085/messages/read`
+
+<br/>
+
 - `GET` /profile/status/:chatId
     
     **Get the status of a person/group**

--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ npm run dev or pnpm dev
 - `POST` /simulate
 
     **Simulate an action (presence)**
-  - **chatId**: The chat number ID. Supports `@s.whatsapp.net`, `@g.us`, and `@c.us` (auto-normalized to `@s.whatsapp.net`)
+  - **chatId**: The chat number ID
   - **action**: The action to simulate: unavailable | available | composing | recording | paused
     ```json
     {
-        "chatId": "5215512345678@s.whatsapp.net",
+        "chatId": "5215512345678@c.us",
         "action": "composing",
     }
     ```

--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ npm run dev or pnpm dev
 - `POST` /simulate
 
     **Simulate an action (presence)**
-  - **chatId**: The chat number ID
+  - **chatId**: The chat number ID. Supports `@s.whatsapp.net`, `@g.us`, and `@c.us` (auto-normalized to `@s.whatsapp.net`)
   - **action**: The action to simulate: unavailable | available | composing | recording | paused
     ```json
     {
-        "chatId": "5215512345678@c.us",
+        "chatId": "5215512345678@s.whatsapp.net",
         "action": "composing",
     }
     ```

--- a/src/app/whatsapp/whatsapp.controller.ts
+++ b/src/app/whatsapp/whatsapp.controller.ts
@@ -5,7 +5,7 @@ import { Chat, Contact, WAPresence } from 'baileys';
 import { FastifyReply } from 'fastify';
 import { Observable, Subject } from 'rxjs';
 import { WebhookService } from '../webhook/webhook.service';
-import { IMessage } from './whatsapp.interface';
+import { IMessage, IReadMessages } from './whatsapp.interface';
 import { WhatsappService } from './whatsapp.service';
 
 @ApiTags('WhatsApp')
@@ -38,6 +38,13 @@ export class WhatsappController {
   async controllerPostSimulate(@Body() payload: { chatId: string; action: WAPresence }): Promise<any> {
     const { chatId, action } = payload;
     return await this.whatsapp.sendSimulate(chatId, action);
+  }
+
+  @Post('messages/read')
+  @ApiProduces('application/json')
+  @ApiConsumes('application/json')
+  async controllerPostReadMessages(@Body() payload: IReadMessages): Promise<any> {
+    return await this.whatsapp.readMessages(payload);
   }
 
   @Get('profile/status/:chatId')

--- a/src/app/whatsapp/whatsapp.interface.ts
+++ b/src/app/whatsapp/whatsapp.interface.ts
@@ -1,8 +1,23 @@
+import { WAPresence } from 'baileys';
+
 interface IContact {
   firstname: string;
   lastname: string;
   phone: string;
   email: string;
+}
+
+export interface IReadMessageKey {
+  remoteJid: string;
+  id: string;
+  fromMe?: boolean;
+  participant?: string;
+}
+
+export interface IReadMessages {
+  keys: IReadMessageKey[];
+  presence?: WAPresence;
+  jid?: string;
 }
 
 export interface IMessage {

--- a/src/app/whatsapp/whatsapp.service.ts
+++ b/src/app/whatsapp/whatsapp.service.ts
@@ -197,7 +197,23 @@ export class WhatsappService {
             // Webhook
             const isMe = to.boolean(item?.key?.fromMe);
             const pushName = to.string(item?.pushName);
-            await this.webhook.send(webhooks, { from, pushName, isMe, type, message, media });
+            const messageId = to.string(item?.key?.id);
+            const participant = to.string(item?.key?.participant);
+            await this.webhook.send(webhooks, {
+              from,
+              pushName,
+              isMe,
+              type,
+              message,
+              messageId,
+              key: {
+                remoteJid: from,
+                id: messageId,
+                fromMe: isMe,
+                participant: participant === '' ? undefined : participant,
+              },
+              media,
+            });
           }
         }
       }

--- a/src/app/whatsapp/whatsapp.service.ts
+++ b/src/app/whatsapp/whatsapp.service.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import NodeCache from '@cacheable/node-cache';
 import { Boom } from '@hapi/boom';
-import { BadRequestException, Injectable, Logger, OnModuleInit, ServiceUnavailableException } from '@nestjs/common';
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { delay, is, to } from '@src/tools';
 import makeWASocket, { Browsers, CacheStore, Chat, ConnectionState, Contact, DisconnectReason, downloadMediaMessage, fetchLatestBaileysVersion, isJidBroadcast, isJidNewsletter, isJidStatusBroadcast, makeCacheableSignalKeyStore, useMultiFileAuthState, WACallEvent, WAMessageKey, WAPresence } from 'baileys';
@@ -143,7 +143,6 @@ export class WhatsappService implements OnModuleInit {
       this.isConnected = false;
     } else if (connection === 'open') {
       text = 'Connected to WhatsApp!';
-      this.isConnected = true;
       this.reconnectCount = 0;
       if (this.reconnectTimeout) {
         clearTimeout(this.reconnectTimeout);
@@ -321,23 +320,12 @@ export class WhatsappService implements OnModuleInit {
    * Simulate  'unavailable' | 'available' | 'composing' | 'recording' | 'paused';
    */
   async sendSimulate(chatId: string, action: WAPresence): Promise<{ chatId: string }> {
-    const jid = this.normalizePresenceJid(chatId);
-
-    if (!this.client || !this.isConnected) {
-      throw new ServiceUnavailableException('WhatsApp is not connected');
-    }
-
-    if (jid === '' || !jid.includes('@')) {
-      throw new BadRequestException('Invalid chatId/JID for presence update');
-    }
-
     try {
-      await this.client.sendPresenceUpdate(action, jid);
-      return { chatId: jid };
+      await this.client.sendPresenceUpdate(action, chatId);
     } catch (e) {
-      this.logger.error('Presence update failed', e);
-      throw e;
+      this.logger.debug(e);
     }
+    return { chatId };
   }
 
   /**
@@ -532,27 +520,6 @@ export class WhatsappService implements OnModuleInit {
 
     const files = fs.readdirSync(sessionPath);
     return files.includes('creds.json');
-  }
-
-  private normalizePresenceJid(chatId: string): string {
-    const value = to.string(chatId).trim();
-    if (value === '') return '';
-
-    if (value.endsWith('@c.us')) {
-      const localPart = value.split('@')[0]?.replace(/\D/g, '') || '';
-      return localPart === '' ? '' : `${localPart}@s.whatsapp.net`;
-    }
-
-    if (value.endsWith('@s.whatsapp.net') || value.endsWith('@g.us')) {
-      return value;
-    }
-
-    if (!value.includes('@')) {
-      const number = value.replace(/\D/g, '');
-      return number === '' ? '' : `${number}@s.whatsapp.net`;
-    }
-
-    return value;
   }
 
   // Read existing data from the JSON file


### PR DESCRIPTION
If you create a volume like  -v whatsapp-auth:/app/auth_info \ in your docker start, the app wil now auto start any session found in it. 

Added /messages/read endpoint to mark message as read (blue tick). Details in README.